### PR TITLE
Add module entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ pip install -r requirements.txt
 python main.py
 ```
 
+También puedes ejecutar la aplicación como un módulo de Python:
+
+```sh
+python -m zpl_to_pdf
+```
+
 ## Compilación a un Ejecutable
 
 ### En macOS

--- a/zpl_to_pdf/__main__.py
+++ b/zpl_to_pdf/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `zpl_to_pdf/__main__.py` so the package can be run with `python -m zpl_to_pdf`
- document the module invocation in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851e85a47e08322a514ae6eb49e8d06